### PR TITLE
Relax ex_aws version and remove unused module attribute

### DIFF
--- a/lib/ex_aws/ssm.ex
+++ b/lib/ex_aws/ssm.ex
@@ -1,9 +1,10 @@
 defmodule ExAws.SSM do
   @moduledoc """
   Documentation for ExAws.SSM.
+  
+  AWS API version 2014-11-06.
   """
   import ExAws.SSM.Utils
-  @version "2014-11-06"
 
   @type decryption_opt :: {:with_decryption, boolean}
   @type pagination_opts ::

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule ExAwsSsm.MixProject do
   defp ex_aws() do
     case System.get_env("AWS") do
       "LOCAL" -> {:ex_aws, path: "../ex_aws"}
-      _ -> {:ex_aws, "~> 2.0.0"}
+      _ -> {:ex_aws, "~> 2.0"}
     end
   end
 end


### PR DESCRIPTION
Removes the unused. `@version` module attributes and documents the version in `@mdoc`.